### PR TITLE
Disable bottom sheet peeking

### DIFF
--- a/AudioRoam/app/src/main/java/edu/uw/abourn/audioroam/MapActivity.java
+++ b/AudioRoam/app/src/main/java/edu/uw/abourn/audioroam/MapActivity.java
@@ -179,7 +179,7 @@ public class MapActivity extends FragmentActivity implements OnMapReadyCallback,
         // set up the upload bottom sheet
         View uploadBottomSheet = findViewById(R.id.upload_bottom_sheet);
         uploadBottomSheetBehavior = BottomSheetBehavior.from(uploadBottomSheet);
-        // collapse the sheet so it is "peeking"
+        // collapse the sheet so it is hidden
         uploadBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
         // register listener for upload fab
         uploadFab = (FloatingActionButton) findViewById(R.id.fab_upload);
@@ -191,19 +191,10 @@ public class MapActivity extends FragmentActivity implements OnMapReadyCallback,
                 if (uploadBottomSheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED) {
                     // validate and submit the uploaded track
                     Log.v(TAG, "collapsing bottom sheet");
-                    // TODO: form validation toggle for submit button
-                    // TODO: if form valid, submit track; else give feedback (snackbar?)
-                    // TODO: on submit success:
-                    //     - collapse bottom sheet and provide feedback on map (STATE_COLLAPSED)
-                    //          - center on added pin, do some fancy confirmation animation
-                    //     - revert button to open state (pink w/ add icon)
-                    // TODO: all of the above (and maybe below) as helper function
-                    uploadBottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+                    uploadBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
                     uploadFab.setImageResource(R.drawable.ic_add_24dp);
                 } else {
                     Log.v(TAG, "expanding bottom sheet");
-                    Log.v(TAG, "fabsize: " + uploadFab.getSize());
-
                     // expand the bottom sheet
                     uploadBottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
                     uploadFab.setImageResource(R.drawable.ic_keyboard_arrow_down_24dp);

--- a/AudioRoam/app/src/main/res/layout/activity_map.xml
+++ b/AudioRoam/app/src/main/res/layout/activity_map.xml
@@ -42,7 +42,6 @@
         android:id="@+id/upload_bottom_sheet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:behavior_peekHeight="80dp"
         app:behavior_hideable="true"
         android:background="#FFF"
         app:layout_behavior="android.support.design.widget.BottomSheetBehavior">


### PR DESCRIPTION
fully hide the upload sheet when it is collapsed